### PR TITLE
fix: version bump

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 # 3. Attempt to curl the correct binary download from GitHub
-VERSION="${KAPSTAN_CLI_VERSION:-0.3.6}"
+VERSION="${KAPSTAN_CLI_VERSION:-0.3.10}"
 BINARY_NAME="kapstan-${OS}-${ARCH}"
 DOWNLOAD_URL="https://github.com/kapstan-io/releases/releases/download/v${VERSION}/${BINARY_NAME}"
 


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Updates the default Kapstan CLI version from 0.3.6 to 0.3.10 in the installation script.

- Modified the default version in `install.sh` from 0.3.6 to 0.3.10 when no specific version is set via the KAPSTAN_CLI_VERSION environment variable.
- Ensures new installations will download the latest stable release (0.3.10) by default.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->